### PR TITLE
genie: Phase2 dedupe-on-create recovery

### DIFF
--- a/docs/design/BE2genie_logic.md
+++ b/docs/design/BE2genie_logic.md
@@ -123,6 +123,16 @@ Legacy preview route: `/genie` or `/preview`
 - Consider converting `readLatest()` to async if legacy routes are updated.
 - Keep `PROMPT_LOG_PATH` config documented for deployment.
 
+### Upcoming implementation (Phase 2)
+
+Planned immediate work (Phase 2) — implementation will be delivered incrementally on its own feature branches, each with deterministic tests and PRs that will be merged into `aetherV0/anew-default-basic` when green.
+
+- `aetherV0/genie-phase2-await` — Add a test-only synchronous persistence mode. When `GENIE_PERSISTENCE_ENABLED=1` and `GENIE_PERSISTENCE_AWAIT=1`, `genieService.generate()` will await `dbUtils.createPrompt` and `dbUtils.createAIResult` before returning so tests can assert `promptId`/`resultId`. Production default remains non-blocking.
+
+- `aetherV0/genie-phase2-dedupe` — Add constraint-safe dedupe handling: if `createPrompt` errors due to a duplicate/unique constraint, the service will query existing prompts and reuse the existing `promptId` instead of failing.
+
+Both branches will include deterministic Vitest tests that inject sync mocks via `genieService`'s injection helpers and will be merged after successful CI runs. Logs and doc updates will be included in each PR.
+
 ---
 
 (Consolidated by automation on 2025-10-20 19:55:27)
@@ -131,7 +141,7 @@ Legacy preview route: `/genie` or `/preview`
 
 Below is a safe, incremental rollout plan to implement the Succinct plan while minimizing risk.
 
-**Phase 0** — Prep & safety (0.5–1 day)
+**Phase 0** — Prep & safety (0.5–1 day) | ✅ (20 OCT 2025)
 
 - Add feature flag: `GENIE_PERSISTENCE_ENABLED=false` by default.
 - Add `server/utils/normalizePrompt.js` (trim + collapse whitespace). Default: do NOT lowercase.
@@ -139,7 +149,7 @@ Below is a safe, incremental rollout plan to implement the Succinct plan while m
 - Sanity: no change to runtime behavior when flag is false.
   Acceptance: repo builds and tests run; server starts with flag=false.
 
-**Phase 1** — Read-only DB lookup in `genieService` (1–2 days)
+**Phase 1** — Read-only DB lookup in `genieService` (1–2 days) | ✅ (21 OCT 2025)
 
 - Implement normalized, read-only DB lookup in `genieService.generate(prompt)`.
 - If found, return cached result; otherwise fall through to generation.

--- a/server/__tests__/genieService.persistence.await.test.mjs
+++ b/server/__tests__/genieService.persistence.await.test.mjs
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// This test runs in ESM test runner but imports the CJS module via require
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+
+describe("genieService persistence await (deterministic)", () => {
+  let genie;
+  beforeEach(() => {
+    // Ensure env flags are set before loading the module
+    process.env.GENIE_PERSISTENCE_ENABLED = "1";
+    process.env.GENIE_PERSISTENCE_AWAIT = "1";
+    // Clear require cache
+    try {
+      delete require.cache[require.resolve("../genieService")];
+    } catch (e) {}
+    genie = require("../genieService");
+  });
+
+  afterEach(() => {
+    delete process.env.GENIE_PERSISTENCE_ENABLED;
+    delete process.env.GENIE_PERSISTENCE_AWAIT;
+    if (genie && genie._resetDbUtils) genie._resetDbUtils();
+    if (genie && genie._resetSampleService) genie._resetSampleService();
+  });
+
+  it("awaits persistence and returns promptId/resultId", async () => {
+    // Inject sync sample service
+    genie._setSampleService({
+      async generateFromPrompt(prompt) {
+        return { content: { title: `T: ${prompt}`, body: prompt }, copies: [] };
+      },
+    });
+
+    // Inject a dbUtils that performs sync-like resolved Promises
+    genie._setDbUtils({
+      async createPrompt(promptText) {
+        return { id: 555 };
+      },
+      async createAIResult(promptId, resultObj) {
+        return { id: 666 };
+      },
+      async getPrompts() {
+        return [];
+      },
+      async getAIResultById() {
+        return null;
+      },
+    });
+
+    const res = await genie.generate("Deterministic test prompt");
+    expect(res).toBeTruthy();
+    expect(res.success).toBe(true);
+    expect(res.data).toBeTruthy();
+    expect(res.data.promptId).toBe(555);
+    expect(res.data.resultId).toBe(666);
+  });
+});

--- a/server/__tests__/genieService.persistence.dedupe.test.mjs
+++ b/server/__tests__/genieService.persistence.dedupe.test.mjs
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// This test injects a dbUtils that throws on createPrompt (simulating a
+// unique constraint failure), but returns an existing prompt when
+// getPrompts() is called. The generator should recover and return the
+// existing promptId without throwing.
+
+describe("genieService persist dedupe-on-create", () => {
+  let genie;
+  beforeEach(() => {
+    // Ensure env flags are set before requiring the module so module-level
+    // constants are evaluated correctly.
+    process.env.GENIE_PERSISTENCE_ENABLED = "1";
+    process.env.GENIE_PERSISTENCE_AWAIT = "1";
+    // Clear module cache and re-require to ensure fresh state
+    delete require.cache[require.resolve("../genieService")];
+    genie = require("../genieService");
+  });
+
+  afterEach(() => {
+    genie._resetDbUtils();
+    genie._resetSampleService();
+    delete process.env.GENIE_PERSISTENCE_ENABLED;
+    delete process.env.GENIE_PERSISTENCE_AWAIT;
+  });
+
+  it("recovers from createPrompt uniqueness error by reusing existing prompt", async () => {
+    // Inject sample service that returns deterministic content
+    genie._setSampleService({
+      async generateFromPrompt(prompt) {
+        return { content: { title: `T: ${prompt}`, body: prompt }, copies: [] };
+      },
+    });
+
+    // Mock dbUtils: createPrompt throws; getPrompts returns existing match; createAIResult succeeds
+    genie._setDbUtils({
+      async createPrompt(promptText) {
+        const e = new Error(
+          "SQLITE_CONSTRAINT: UNIQUE constraint failed: prompt"
+        );
+        e.code = "SQLITE_CONSTRAINT";
+        throw e;
+      },
+      async getPrompts(limit) {
+        return [{ id: 77, prompt: "Hello dedupe test" }];
+      },
+      async createAIResult(promptId, resultObj) {
+        return { id: 88 };
+      },
+      async getAIResultById() {
+        return null;
+      },
+    });
+
+    process.env.GENIE_PERSISTENCE_ENABLED = "1";
+    process.env.GENIE_PERSISTENCE_AWAIT = "1";
+
+    const r = await genie.generate("Hello dedupe test");
+    expect(r).toBeDefined();
+    expect(r.success).toBe(true);
+    expect(r.data.promptId).toBe(77);
+    expect(r.data.resultId).toBe(88);
+  });
+});

--- a/server/genieService.js
+++ b/server/genieService.js
@@ -8,6 +8,10 @@ const ENABLE_PERSISTENCE =
   process.env.GENIE_PERSISTENCE_ENABLED === "1" ||
   process.env.GENIE_PERSISTENCE_ENABLED === "true";
 
+const AWAIT_PERSISTENCE =
+  process.env.GENIE_PERSISTENCE_AWAIT === "1" ||
+  process.env.GENIE_PERSISTENCE_AWAIT === "true";
+
 const genieService = {
   // For the demo, generate delegates to sampleService. In future this can
   // orchestrate real AI/image jobs via aetherService.
@@ -92,7 +96,19 @@ const genieService = {
       // If persistence is enabled, attempt to persist the prompt and AI result.
       // This is best-effort and must not block or fail the generation response.
       if (ENABLE_PERSISTENCE) {
-        (async () => {
+        // Provide a Promise hook that tests can await to know when the
+        // persistence attempt completes. This hook is optional and only used
+        // by tests that set GENIE_PERSISTENCE_AWAIT=1.
+        let persistenceResolver;
+        let persistenceRejecter;
+        const persistencePromise = new Promise((res, rej) => {
+          persistenceResolver = res;
+          persistenceRejecter = rej;
+        });
+        // Expose test hook
+        genieService._lastPersistencePromise = persistencePromise;
+
+        const runPersistence = async () => {
           try {
             const dbUtils =
               typeof _injectedDbUtils !== "undefined"
@@ -127,6 +143,7 @@ const genieService = {
                 e && e.message
               );
             }
+            persistenceResolver();
           } catch (e) {
             // Non-fatal: log and ignore persistence failures
             // eslint-disable-next-line no-console
@@ -134,8 +151,24 @@ const genieService = {
               "genieService: persistence step failed",
               e && e.message
             );
+            persistenceRejecter(e);
+          } finally {
+            // Clear the last persistence promise after it's settled
+            setImmediate(() => {
+              genieService._lastPersistencePromise = undefined;
+            });
           }
-        })();
+        };
+
+        if (AWAIT_PERSISTENCE) {
+          // Await persistence synchronously (test-only mode)
+          await runPersistence();
+        } else {
+          // Fire-and-forget for normal operation
+          (async () => {
+            await runPersistence();
+          })();
+        }
       }
 
       return out;

--- a/server/genieService.js
+++ b/server/genieService.js
@@ -114,10 +114,48 @@ const genieService = {
               typeof _injectedDbUtils !== "undefined"
                 ? _injectedDbUtils
                 : require("./utils/dbUtils");
-
-            // Create prompt record
+            // Create prompt record with dedupe-on-create handling.
             try {
-              const p = await dbUtils.createPrompt(String(prompt));
+              let p;
+              try {
+                p = await dbUtils.createPrompt(String(prompt));
+              } catch (createErr) {
+                // If create failed due to a uniqueness/constraint error,
+                // attempt to recover by searching for an existing prompt
+                // that matches the normalized text. This avoids throwing
+                // when concurrent requests race to create the same prompt.
+                // Normalize and search recent prompts for a match.
+                try {
+                  const norm = normalizePrompt(prompt);
+                  const recent = await dbUtils.getPrompts(200);
+                  const found = (recent || []).find((r) => {
+                    try {
+                      return (
+                        typeof r.prompt === "string" &&
+                        normalizePrompt(r.prompt) === norm
+                      );
+                    } catch (e) {
+                      return false;
+                    }
+                  });
+                  if (found && found.id) {
+                    p = { id: found.id };
+                  } else {
+                    // Re-throw original create error if we couldn't recover
+                    throw createErr;
+                  }
+                } catch (recoverErr) {
+                  // Log recovery failure and rethrow original create error
+                  // eslint-disable-next-line no-console
+                  console.warn(
+                    "genieService: createPrompt failed and recovery failed",
+                    createErr && createErr.message,
+                    recoverErr && recoverErr.message
+                  );
+                  throw createErr;
+                }
+              }
+
               if (p && p.id) out.data.promptId = p.id;
 
               // Create AI result record linked to the prompt


### PR DESCRIPTION
Add dedupe-on-create recovery when createPrompt races occur. If createPrompt fails due to uniqueness, genieService will lookup recent prompts and reuse existing promptId. Includes deterministic test .